### PR TITLE
Correct SymPyDeprecationWarning

### DIFF
--- a/complex_and_trig.ipynb
+++ b/complex_and_trig.ipynb
@@ -375,7 +375,7 @@
     "\n",
     "# Solve for ω\n",
     "## Note: we choose the solution near 0\n",
-    "eq1 = Eq(x1/x0 - r * cos(ω+θ) / cos(ω))\n",
+    "eq1 = Eq(x1/x0 - r * cos(ω+θ) / cos(ω), 0)\n",
     "ω = nsolve(eq1, ω, 0)\n",
     "ω = np.float(ω)\n",
     "print(f'ω = {ω:1.3f}')\n",


### PR DESCRIPTION
```
/srv/conda/envs/notebook/lib/python3.7/site-packages/sympy/core/relational.py:470: SymPyDeprecationWarning: 

Eq(expr) with rhs default to 0 has been deprecated since SymPy 1.5.
Use Eq(expr, 0) instead. See
https://github.com/sympy/sympy/issues/16587 for more info.

  deprecated_since_version="1.5"
```